### PR TITLE
Update how-to-block-network-traffic-powershell.md

### DIFF
--- a/articles/virtual-network-manager/how-to-block-network-traffic-powershell.md
+++ b/articles/virtual-network-manager/how-to-block-network-traffic-powershell.md
@@ -69,7 +69,7 @@ Before you start configuring security rules, confirm the following steps:
     [System.Collections.Generic.List[Microsoft.Azure.Commands.Network.Models.PSNetworkManagerSecurityGroupItem]]$configGroup = @()  
     $configGroup.Add($groupItem) 
 
-    $configGroup = @($groupItem)
+
     ```
 
 1. Create a security admin rules collection with New-AzNetworkManagerSecurityAdminRuleCollection.
@@ -80,9 +80,9 @@ Before you start configuring security rules, confirm the following steps:
         ResourceGroupName = 'myAVNMResourceGroup'
         NetworkManager = 'myAVNM'
         ConfigName = 'SecurityConfig'
-        AppliesToGroup = "$configGroup"
+        AppliesToGroup = $configGroup
     }
-    $rulecollection = New-AzNetworkManagerSecurityAdminRuleCollection @collection -AppliesToGroup $configGroup
+    $rulecollection = New-AzNetworkManagerSecurityAdminRuleCollection @collection
     ```
 
 1. Define the variables for the source and destination address prefixes and ports with New-AzNetworkManagerAddressPrefixItem.


### PR DESCRIPTION
##Line 72 
$configGroup = @($groupItem)
Error: Cannot convert the "System.Object[]" value of type "System.Object[]" to type "Microsoft.Azure.Commands.Network.Models.NetworkManager.PSNetworkManagerSecurityGroupItem". Workaround: Delete the line

##Line 81
AppliesToGroup = "$configGroup"
Error: Instead of give us the result of the $configGroup, it retrieves "Microsoft.Azure.Commands.Network.Models.NetworkManager.PSNetworkManagerSecurityGroupItem" Workaround: Remove the quotation marks

##Line 85
$rulecollection = New-AzNetworkManagerSecurityAdminRuleCollection @collection -AppliesToGroup $configGroup Error: Cannot bind parameter because parameter 'AppliesToGroup' is specified more than once Workaround: Remove "-AppliesToGroup $configGroup"